### PR TITLE
Allow create session and destroy session to throw.

### DIFF
--- a/Sources/Turnstile/SessionManager/SessionManager.swift
+++ b/Sources/Turnstile/SessionManager/SessionManager.swift
@@ -18,10 +18,10 @@ public protocol SessionManager {
     func restoreAccount(fromSessionID identifier: String) throws -> Account
     
     /// Creates a session for a given Account object and returns the identifier.
-    func createSession(account: Account) -> String
+    func createSession(account: Account) throws -> String
     
     /// Destroys the session for a session identifier.
-    func destroySession(identifier: String)
+    func destroySession(identifier: String) throws
 }
 
 /**


### PR DESCRIPTION
Took the liberty of adding 'throws' to both `destroySession` and `createSession`. If you disagree with this, feel free to close and do whatever you think is best. 

FYI, my use case for idestroySession' throwing is because the call to the database to delete the session could fail and I would like to communicate this to the callee of the API. 