### PR TITLE
Add accessToken property to FacebookAccount

### DIFF
--- a/Sources/TurnstileWeb/LoginProviders/Facebook.swift
+++ b/Sources/TurnstileWeb/LoginProviders/Facebook.swift
@@ -63,7 +63,7 @@ public class Facebook: OAuth2, Realm {
 
         if let accountID = responseData["user_id"] as? String
             , responseData["app_id"] as? String == clientID && responseData["is_valid"] as? Bool == true {
-            return FacebookAccount(uniqueID: accountID)
+            return FacebookAccount(uniqueID: accountID, accessToken: credentials.string)
         }
         
         throw IncorrectCredentialsError()
@@ -82,6 +82,7 @@ public class Facebook: OAuth2, Realm {
 public struct FacebookAccount: Account, Credentials {
     // TODO: represent a lot more from the Facebook account.
     public let uniqueID: String
+    public let accessToken: String
 }
 
 /**

--- a/Sources/TurnstileWeb/LoginProviders/Google.swift
+++ b/Sources/TurnstileWeb/LoginProviders/Google.swift
@@ -55,8 +55,8 @@ public class Google: OAuth2, Realm {
         }
         
         if let accountID = json["sub"] as? String
-            , (json["aud"] as? String)?.components(separatedBy: "-").first == clientID.components(separatedBy: "-").first {
-            return GoogleAccount(uniqueID: accountID)
+            , (json["aud"] as? String)?.components(separatedBy: "-").first == clientID.components(separatedBy: "-").first, let email = json["email"] as? String {
+            return GoogleAccount(uniqueID: accountID, accessToken: credentials.string, email: email)
         }
         
         throw IncorrectCredentialsError()
@@ -72,6 +72,8 @@ public class Google: OAuth2, Realm {
  */
 public struct GoogleAccount: Account, Credentials {
     public let uniqueID: String
+    public let accessToken: String
+    public let email: String
 }
 
 /// TODO: refactor facebook and google to using this to an "unknown" OAuth error.


### PR DESCRIPTION
This was needed to make Graph API calls after user has successfully logged in with Facebook.