### PR TITLE
Return the Google account with email

### DIFF
--- a/Sources/TurnstileWeb/LoginProviders/Google.swift
+++ b/Sources/TurnstileWeb/LoginProviders/Google.swift
@@ -58,7 +58,7 @@ public class Google: OAuth2, Realm {
             , (json["aud"] as? String)?.components(separatedBy: "-").first == clientID.components(separatedBy: "-").first {
             var account = GoogleAccount(uniqueID: accountID, accessToken: credentials)
             account.email = json["email"] as? String
-            return GoogleAccount(uniqueID: accountID, accessToken: credentials)
+            return account
         }
         
         throw IncorrectCredentialsError()


### PR DESCRIPTION
The email address is being set on an `account` variable, but then a completely new instance of GoogleAccount was returned, so the email information was lost.  Now the instance that has the email field set is returned.